### PR TITLE
ci: add workflow to update changelog page

### DIFF
--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -1,0 +1,84 @@
+# This workflow is triggered from other repositories in the Bucketeer Organization
+# to update the CHANGELOG SDKs pages.
+# In case of changes in the template (`update-changelog.sh`), we also might need to update the trigger side.
+
+name: update-changelog
+
+on:
+  workflow_dispatch:
+    inputs:
+      doc_filename:
+        description: "Doc filename"
+        type: string
+        required: true
+      doc_filepath:
+        description: "Doc filepath"
+        type: string
+        required: true
+      doc_title:
+        description: "Doc title"
+        type: string
+        required: true
+      doc_slug:
+        description: "Doc slug"
+        type: string
+        required: true
+      changelog_url:
+        description: "Changelog URL"
+        type: string
+        required: true
+      from_repository_name:
+        description: "From repository name"
+        type: string
+        required: true
+      from_repository_url:
+        description: "From repository URL"
+        type: string
+        required: true
+      commit_url:
+        description: "Commit URL"
+        type: string
+        required: true
+      release_tag:
+        description: "Release Tag"
+        type: string
+        required: true
+
+jobs:
+  create-and-merge-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update the CHANGELOG.md file
+        env:
+          DOC_FILENAME: ${{ github.event.inputs.doc_filename }}
+          DOC_FILEPATH: ${{ github.event.inputs.doc_filepath }}
+          DOC_TITLE: ${{ github.event.inputs.doc_title }}
+          DOC_SLUG: ${{ github.event.inputs.doc_slug }}
+          CHANGELOG_URL: ${{ github.event.inputs.changelog_url }}
+        run: ./hack/create-changelog.sh
+
+      - name: Create the pull request
+        id: create-docs-pull-request
+        uses: peter-evans/create-pull-request@b1ddad2c994a25fbc81a28b3ec0e368bb2021c50 # v6.0.0
+        with:
+          token: ${{ secrets.ACTIONS_PAT }}
+          committer: bucketeer-bot <bucketeer-bot@users.noreply.github.com>
+          author: bucketeer-bot <bucketeer-bot@users.noreply.github.com>
+          commit-message: "docs: update ${{ github.event.inputs.doc_filename }} to ${{ github.event.inputs.release_tag }}"
+          title: "docs: update ${{ github.event.inputs.doc_filename }} changelog to ${{ github.event.inputs.release_tag }}"
+          body: "[${{ github.event.inputs.from_repository_name }}](${{ github.event.inputs.from_repository_url }}) commit: ${{ github.event.inputs.commit_url }}"
+          branch: "ci-docs-pr-${{ github.event.inputs.release_tag }}"
+          delete-branch: true
+          labels: automerge
+
+      - name: Merge the pull request
+        id: automerge
+        uses: pascalgn/automerge-action@58724c982461efbb7865b3762d7bff0d4756f57a # v0.16.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_PAT }}
+          PULL_REQUEST: ${{ steps.create-docs-pull-request.outputs.pull-request-number }}
+          MERGE_LABELS: automerge
+          MERGE_METHOD: squash
+          MERGE_ERROR_FAIL: true

--- a/hack/update-changelog.sh
+++ b/hack/update-changelog.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# This script is triggered from other repositories in the Bucketeer Organization
+# to update the CHANGELOG SDKs pages.
+# In case of changes in the template, we also might need to update the trigger side.
+
+# Envs
+CHANGELOG_TEMP_FILE=changelog_temp.md
+
+echo "DOC_FILENAME = $DOC_FILENAME"
+echo "DOC_FILEPATH = $DOC_FILEPATH"
+echo "DOC_TITLE = $DOC_TITLE"
+echo "DOC_SLUG = $DOC_SLUG"
+echo "CHANGELOG_URL = $CHANGELOG_URL"
+echo "PWD = $PWD"
+
+# Download the CHANGELOG.md
+curl -o $CHANGELOG_TEMP_FILE $CHANGELOG_URL
+
+# Remove the first line (The H1 # CHANGELOG)
+sed -i'' -e '1d' $CHANGELOG_TEMP_FILE
+
+# Reformat the data from (YYYY-MM-DD) to (YYYY/MM/DD)
+sed -i'' -e 's/\(\([0-9]\{4\}\)-\([0-9]\{2\}\)-\([0-9]\{2\}\)\)/\2\/\3\/\4/g' $CHANGELOG_TEMP_FILE
+
+# Write the new CHANGELOG.md
+file=$(cat << EOF
+---
+title: ${DOC_TITLE}
+slug: ${DOC_SLUG}
+toc_max_heading_level: 2
+---
+
+<style>
+  {\`
+    h2:not(:first-of-type) {
+      border-top: 2px solid #ddd7e9;
+      padding-top: 40px;
+    }
+  \`}
+</style>
+
+$(cat $CHANGELOG_TEMP_FILE)
+
+EOF
+)
+
+# Override the current file
+# The file path MUST exist or it will fail.
+echo "$file" > ./${DOC_FILEPATH}/${DOC_FILENAME}
+cat ./${DOC_FILEPATH}/${DOC_FILENAME}
+
+# Delete the temp file
+rm $CHANGELOG_TEMP_FILE
+
+echo "File ./${DOC_FILENAME} updated."


### PR DESCRIPTION
Part of https://github.com/bucketeer-io/bucketeer/issues/814

The other repositories will trigger this workflow to update their changelog pages.
Every time the other repositories release a new tag, it automatically triggers this workflow.

#### Flow

```
Triggered
↓
Download the latest CHANGELOG.md
↓
Overrides the current one
↓
Create the PR
↓
Automatically Merge PR
```

E.g.

![Screenshot 2024-02-09 at 2 01 24 PM](https://github.com/bucketeer-io/bucketeer-docs/assets/2486691/cdf85da2-b087-4add-a982-4bd96bbdfcd8)
