### PR TITLE
fix: api-reference background no longer has black area

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -111,6 +111,10 @@
   --docusaurus-details-decoration-color: #5d3597;
 }
 
+#__docusaurus {
+  background-color: #ffffff;
+}
+
 .markdown h1 {
   --ifm-h1-font-size: 2.125rem !important;
 }


### PR DESCRIPTION
Resolve issue https://github.com/bucketeer-io/bucketeer-docs/issues/141
- Add default background color
- Before:
![image](https://github.com/user-attachments/assets/1d375a24-6bc9-4b5e-8553-4b42318185e5)

- After:
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/5195a36b-2049-48f1-8ef3-689f997a67c3">
