### PR TITLE
docs: add getting evaluation details section to go sdk doc

### DIFF
--- a/docs/sdk/index.mdx
+++ b/docs/sdk/index.mdx
@@ -228,6 +228,11 @@ The table below illustrates all features available in each one of the available 
         <td><CheckSVG/></td>
       </tr>
       <tr>
+        <td>Local/Remote evaluation</td>
+        <td><CheckSVG/></td>
+        <td><CheckSVG/></td>
+      </tr>
+      <tr>
         <td>Getting evaluation details</td>
         <td><CheckSVG/></td>
         <td><CheckSVG/></td>

--- a/docs/sdk/index.mdx
+++ b/docs/sdk/index.mdx
@@ -228,6 +228,11 @@ The table below illustrates all features available in each one of the available 
         <td><CheckSVG/></td>
       </tr>
       <tr>
+        <td>Getting evaluation details</td>
+        <td><CheckSVG/></td>
+        <td><CheckSVG/></td>
+      </tr>
+      <tr>
         <td>Reporting custom events</td>
         <td><CheckSVG/></td>
         <td><CheckSVG/></td>


### PR DESCRIPTION
fix #175

- Add `getting evaluation details` section to go sdk doc as well as other sdk client.
- Fix tables of server sdk.
- Use code go-server-sdk(https://github.com/bucketeer-io/go-server-sdk/blob/2f3f0b01a619c516664d49bd65a3beabe7c2ef07/pkg/bucketeer/sdk.go#L33-L34)

