### PR TITLE
docs: replace `WithHost` to `WithAPIEndpoint` in go examples

### DIFF
--- a/docs/getting-started/quickstart/integrate-bucketeer.mdx
+++ b/docs/getting-started/quickstart/integrate-bucketeer.mdx
@@ -223,7 +223,7 @@ defer cancel()
 client, err := bucketeer.NewSDK(
   ctx,
   bucketeer.WithAPIKey("YOUR_API_KEY"),
-  bucketeer.WithHost("YOUR_API_ENDPOINT"),
+  bucketeer.WithAPIEndpoint("YOUR_API_ENDPOINT"),
   bucketeer.WithTag("YOUR_FEATURE_TAG"),
 )
 if err != nil {

--- a/docs/sdk/server-side/go/index.md
+++ b/docs/sdk/server-side/go/index.md
@@ -96,7 +96,7 @@ defer cancel()
 client, err := bucketeer.NewSDK(
   ctx,
   bucketeer.WithAPIKey("YOUR_API_KEY"),
-  bucketeer.WithHost("YOUR_API_ENDPOINT"),
+  bucketeer.WithAPIEndpoint("YOUR_API_ENDPOINT"),
   bucketeer.WithTag("YOUR_FEATURE_TAG"),
 )
 if err != nil {
@@ -134,7 +134,7 @@ defer cancel()
 client, err := bucketeer.NewSDK(
   ctx,
   bucketeer.WithAPIKey("YOUR_API_KEY"),
-  bucketeer.WithHost("YOUR_API_ENDPOINT"),
+  bucketeer.WithAPIEndpoint("YOUR_API_ENDPOINT"),
   bucketeer.WithTag("YOUR_FEATURE_TAG"),
   bucketeer.WithEnableLocalEvaluation(true), // <--- Enable the local evaluation
   bucketeer.WithCachePollingInterval(10*time.Minute), // <--- Change the default interval if needed


### PR DESCRIPTION

`WithHost` has already been deprecated, and `WithAPIEndpoint` is recommended instead.

https://github.com/bucketeer-io/go-server-sdk/blob/5cb6d3da9f6713cab02c0c82397a5f8476c7e1d2/pkg/bucketeer/option.go#L102-L109