### PR TITLE
chore: update react SDK support react 19

### DIFF
--- a/docs/sdk/client-side/react-native/index.md
+++ b/docs/sdk/client-side/react-native/index.md
@@ -26,9 +26,12 @@ Bucketeer React Native SDK is a beta version. Breaking changes may be introduced
 Before starting, ensure that you follow the [Getting Started](/getting-started) guide.
 
 **React Native Version Support:**
-- ✅ Supported: React 18.2.0 - 18.3.x and React Native 0.76.0 - 0.78.x
-- ⚠️ May work: React 18.0.0 - 18.1.x (not officially supported)
-- ❌ Not supported: React 19.0.0 and above, React Native 0.79.0 and above
+
+| Status | React Version | React Native Version |
+| :--- | :--- | :--- |
+| **Supported** | 18.2.0 - 18.3.x | 0.76.0 - 0.78.x |
+| **May work** | 18.0.0 - 18.1.x | (not officially supported) |
+| **Not supported** | 19.0.0 and above | 0.79.0 and above |
 
 ## Getting started
 

--- a/docs/sdk/client-side/react-native/index.md
+++ b/docs/sdk/client-side/react-native/index.md
@@ -30,8 +30,7 @@ Before starting, ensure that you follow the [Getting Started](/getting-started) 
 | Status | React Version | React Native Version |
 | :--- | :--- | :--- |
 | **Supported** | 18.2.0 - 18.3.x | 0.76.0 - 0.78.x |
-| **May work** | 18.0.0 - 18.1.x | (not officially supported) |
-| **Not supported** | 19.0.0 and above | 0.79.0 and above |
+| **Supported** | 19.0.0 and above | 0.79.0 and above |
 
 ## Getting started
 

--- a/docs/sdk/client-side/react-native/index.md
+++ b/docs/sdk/client-side/react-native/index.md
@@ -15,6 +15,14 @@ Bucketeer React Native SDK is a beta version. Breaking changes may be introduced
 
 :::
 
+:::info Compatibility
+
+The Bucketeer SDK is compatible with:
+- React 18.2.0 - 18.3.x and React Native 0.76.0 - 0.78.x
+- React 19.0.0 and above and React Native 0.79.0 and above
+
+:::
+
 ## Key Points
 
 - Most APIs and usage are **identical** to the [React SDK](/sdk/client-side/react)
@@ -24,13 +32,6 @@ Bucketeer React Native SDK is a beta version. Breaking changes may be introduced
 ## Requirements
 
 Before starting, ensure that you follow the [Getting Started](/getting-started) guide.
-
-**React Native Version Support:**
-
-| Status | React Version | React Native Version |
-| :--- | :--- | :--- |
-| **Supported** | 18.2.0 - 18.3.x | 0.76.0 - 0.78.x |
-| **Supported** | 19.0.0 and above | 0.79.0 and above |
 
 ## Getting started
 

--- a/docs/sdk/client-side/react/index.md
+++ b/docs/sdk/client-side/react/index.md
@@ -17,18 +17,21 @@ Bucketeer React SDK is a beta version. Breaking changes may be introduced before
 
 ## Features
 
-- 🚀 React Context and Hooks for easy integration
-- 🔧 TypeScript support with full type safety
-- 🔄 Automatic re-rendering on flag changes
+- React Context and Hooks for easy integration
+- TypeScript support with full type safety
+- Automatic re-rendering on flag changes
 
 ## Requirements
 
 Before starting, ensure that you follow the [Getting Started](/getting-started) guide.
 
-**React Version Support:**
-- ✅ Supported: React 18.2.0 - 18.3.x
-- ⚠️ May work: React 18.0.0 - 18.1.x (not officially supported)
-- ❌ Not supported: React 19.0.0 and above
+**React Version Support**
+
+| Status | React Version |
+| :--- | :--- |
+| **Supported** | 18.2.0 - 18.3.x |
+| **May work** | 18.0.0 - 18.1.x (not officially supported) |
+| **Not supported** | 19.0.0 and above |
 
 ## Getting started
 

--- a/docs/sdk/client-side/react/index.md
+++ b/docs/sdk/client-side/react/index.md
@@ -29,9 +29,8 @@ Before starting, ensure that you follow the [Getting Started](/getting-started) 
 
 | Status | React Version |
 | :--- | :--- |
-| **Supported** | 18.2.0 - 18.3.x |
+| **Supported** | React 18.2.0 and above |
 | **May work** | 18.0.0 - 18.1.x (not officially supported) |
-| **Not supported** | 19.0.0 and above |
 
 ## Getting started
 

--- a/docs/sdk/client-side/react/index.md
+++ b/docs/sdk/client-side/react/index.md
@@ -15,6 +15,12 @@ Bucketeer React SDK is a beta version. Breaking changes may be introduced before
 
 :::
 
+:::info Compatibility
+
+The Bucketeer SDK is compatible with React versions 18.2.0 and higher. Versions 18.0.0 - 18.1.x may work but are not officially supported.
+
+:::
+
 ## Features
 
 - React Context and Hooks for easy integration
@@ -24,13 +30,6 @@ Bucketeer React SDK is a beta version. Breaking changes may be introduced before
 ## Requirements
 
 Before starting, ensure that you follow the [Getting Started](/getting-started) guide.
-
-**React Version Support**
-
-| Status | React Version |
-| :--- | :--- |
-| **Supported** | React 18.2.0 and above |
-| **May work** | 18.0.0 - 18.1.x (not officially supported) |
 
 ## Getting started
 


### PR DESCRIPTION
This pull request updates the documentation for the React and React Native SDKs to clarify and standardize the version support information. The main changes involve replacing the previous bullet-point lists with tables for better readability and updating the supported version ranges.

**Documentation improvements:**

* [`docs/sdk/client-side/react/index.md`](diffhunk://#diff-4462a9105da507c94c2f9a8e70d6c2e0b1b33c4f60de349d725f9d5d8b04a9eeL20-R33): Replaced the bullet-point list of supported React versions with a table, clarified that React 18.2.0 and above are supported, and retained the note about unofficial support for 18.0.0 - 18.1.x.
* [`docs/sdk/client-side/react-native/index.md`](diffhunk://#diff-f2d6efadf1e475b680908aa8fb02a08972feb1c097530a3b1040afe2e8a0ec51L29-R33): Updated the React Native version support section to use a table format and clarified that both React 18.2.0 - 18.3.x with React Native 0.76.0 - 0.78.x, and React 19.0.0 and above with React Native 0.79.0 and above are supported.