### PR TITLE
docs: use defineBKTConfigForReactNative for OpenFeature ReactNative provider

### DIFF
--- a/docs/open-feature/react-native/index.md
+++ b/docs/open-feature/react-native/index.md
@@ -64,13 +64,13 @@ Please use the [OpenFeature React SDK](https://openfeature.dev/docs/reference/sd
 
 #### Configuration & Initialization
 
-Use `defineBKTConfig` to create your configuration and set up the `OpenFeatureProvider`. Make sure to use the global `fetch` API.
+Use `defineBKTConfigForReactNative` to create your configuration and set up the `OpenFeatureProvider`. Make sure to use the global `fetch` API.
 
 ```js showLineNumbers
 import { OpenFeatureProvider, OpenFeature } from '@openfeature/react-sdk';
-import { defineBKTConfig, BucketeerReactNativeProvider } from '@bucketeer/openfeature-js-client-sdk';
+import { defineBKTConfigForReactNative, BucketeerReactNativeProvider } from '@bucketeer/openfeature-js-client-sdk';
 
-const config = defineBKTConfig({
+const config = defineBKTConfigForReactNative({
   apiEndpoint: 'BUCKETEER_API_ENDPOINT',
   apiKey: 'BUCKETEER_API_KEY',
   featureTag: 'FEATURE_TAG',
@@ -101,7 +101,7 @@ function App() {
 See our [documentation](https://docs.bucketeer.io/sdk/client-side/javascript#configuring-client) for more SDK configuration.
 
 :::important
-In the React Native environment, any `idGenerator` or `storageFactory` provided in the configuration will be **ignored**. The `BucketeerReactNativeProvider` automatically provides specialized React Native implementations for these during initialization.
+Use `defineBKTConfigForReactNative` for the standard setup — you do not need to provide an `idGenerator`. The `BucketeerReactNativeProvider` automatically loads and injects the correct React Native implementation (`react-native-uuid`) during initialization.
 :::
 
 #### Evaluate a feature flag
@@ -146,5 +146,5 @@ await OpenFeature.setContext(newEvaluationContext)
 ```
 
 :::warning
-Changing the `targetingKey` is not supported in the current implementation of the BucketeerProvider. To change the user ID, the Provider must be removed and reinitialized exactly as demonstrated in the [JavaScript / Web section](/open-feature/javascript#update-the-evaluation-context).
+Changing the `targetingKey` is not supported in the current implementation of the BucketeerReactNativeProvider. To change the user ID, the Provider must be removed and reinitialized exactly as demonstrated in the [JavaScript / Web section](/open-feature/javascript#update-the-evaluation-context).
 :::

--- a/docs/open-feature/react-native/index.md
+++ b/docs/open-feature/react-native/index.md
@@ -64,6 +64,9 @@ Please use the [OpenFeature React SDK](https://openfeature.dev/docs/reference/sd
 
 #### Configuration & Initialization
 
+> [!WARNING]
+> Make sure not to use defineConfig in the React Native environment, as it is not supported.
+
 Use `defineBKTConfigForReactNative` to create your configuration and set up the `OpenFeatureProvider`. Make sure to use the global `fetch` API.
 
 ```js showLineNumbers
@@ -99,10 +102,6 @@ function App() {
 ```
 
 See our [documentation](https://docs.bucketeer.io/sdk/client-side/javascript#configuring-client) for more SDK configuration.
-
-:::important
-Use `defineBKTConfigForReactNative` for the standard setup — you do not need to provide an `idGenerator`. During initialization, `BucketeerReactNativeProvider` uses the React Native ID generator implementation backed by `react-native-uuid`, which must be installed and available at runtime.
-:::
 
 #### Evaluate a feature flag
 

--- a/docs/open-feature/react-native/index.md
+++ b/docs/open-feature/react-native/index.md
@@ -101,7 +101,7 @@ function App() {
 See our [documentation](https://docs.bucketeer.io/sdk/client-side/javascript#configuring-client) for more SDK configuration.
 
 :::important
-Use `defineBKTConfigForReactNative` for the standard setup — you do not need to provide an `idGenerator`. The `BucketeerReactNativeProvider` automatically loads and injects the correct React Native implementation (`react-native-uuid`) during initialization.
+Use `defineBKTConfigForReactNative` for the standard setup — you do not need to provide an `idGenerator`. During initialization, `BucketeerReactNativeProvider` uses the React Native ID generator implementation backed by `react-native-uuid`, which must be installed and available at runtime.
 :::
 
 #### Evaluate a feature flag

--- a/docs/open-feature/react-native/index.md
+++ b/docs/open-feature/react-native/index.md
@@ -103,6 +103,9 @@ function App() {
 
 See our [documentation](https://docs.bucketeer.io/sdk/client-side/javascript#configuring-client) for more SDK configuration.
 
+> [!IMPORTANT]
+> In the React Native environment, any `idGenerator` or `storageFactory` provided in the configuration will be **ignored**. The `BucketeerReactNativeProvider` automatically provides specialized React Native implementations for these during initialization.
+
 #### Evaluate a feature flag
 
 The OpenFeature React SDK provides hooks for evaluating feature flags.

--- a/docs/open-feature/react-native/index.md
+++ b/docs/open-feature/react-native/index.md
@@ -66,7 +66,7 @@ Please use the [OpenFeature React SDK](https://openfeature.dev/docs/reference/sd
 
 :::warning
 
-Make sure not to use defineConfig in the React Native environment, as it is not supported.
+Make sure not to use `defineConfig` in the React Native environment, as it is not supported.
 
 :::
 

--- a/docs/open-feature/react-native/index.md
+++ b/docs/open-feature/react-native/index.md
@@ -66,7 +66,7 @@ Please use the [OpenFeature React SDK](https://openfeature.dev/docs/reference/sd
 
 :::warning
 
-Make sure not to use `defineConfig` in the React Native environment, as it is not supported.
+Make sure not to use `defineBKTConfig` in the React Native environment, as it is not supported.
 
 :::
 

--- a/docs/open-feature/react-native/index.md
+++ b/docs/open-feature/react-native/index.md
@@ -64,8 +64,11 @@ Please use the [OpenFeature React SDK](https://openfeature.dev/docs/reference/sd
 
 #### Configuration & Initialization
 
-> [!WARNING]
-> Make sure not to use defineConfig in the React Native environment, as it is not supported.
+:::warning
+
+Make sure not to use defineConfig in the React Native environment, as it is not supported.
+
+:::
 
 Use `defineBKTConfigForReactNative` to create your configuration and set up the `OpenFeatureProvider`. Make sure to use the global `fetch` API.
 
@@ -103,8 +106,9 @@ function App() {
 
 See our [documentation](https://docs.bucketeer.io/sdk/client-side/javascript#configuring-client) for more SDK configuration.
 
-> [!IMPORTANT]
-> In the React Native environment, any `idGenerator` or `storageFactory` provided in the configuration will be **ignored**. The `BucketeerReactNativeProvider` automatically provides specialized React Native implementations for these during initialization.
+:::note
+In the React Native environment, any `idGenerator` or `storageFactory` provided in the configuration will be **ignored**. The `BucketeerReactNativeProvider` automatically provides specialized React Native implementations for these during initialization.
+:::
 
 #### Evaluate a feature flag
 


### PR DESCRIPTION
This pull request updates the React Native integration documentation for OpenFeature and Bucketeer to clarify usage and improve accuracy. The most important changes are:

**React Native-specific configuration guidance:**

* Updated the documentation to warn against using `defineConfig` in React Native, and instead instructs users to use `defineBKTConfigForReactNative` for configuration. All relevant code examples and import statements have been updated accordingly.

**Provider implementation details:**

* Clarified that in the React Native environment, any `idGenerator` or `storageFactory` provided in the configuration will be ignored, as the `BucketeerReactNativeProvider` supplies specialized implementations. The note is now formatted as an important callout for better visibility.

**Correct provider naming:**

* Fixed a documentation error by replacing references to `BucketeerProvider` with the correct `BucketeerReactNativeProvider` when describing targeting key limitations and user ID changes.