### PR TITLE
ci: replace classic pat with github app token

### DIFF
--- a/.github/workflows/ai-docs-update.yaml
+++ b/.github/workflows/ai-docs-update.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Fetch issue and PR context from bucketeer repo
         id: context
         env:
-          GH_TOKEN: ${{ secrets.REPO_ACCESS_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # bucketeer-io/bucketeer is public, read-only API access needs no PAT
           INPUT_ISSUE_NUMBER: ${{ inputs.issue_number }}
           INPUT_PR_NUMBERS: ${{ inputs.pr_numbers }}
         run: |

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -59,11 +59,19 @@ jobs:
           CHANGELOG_URL: ${{ github.event.inputs.changelog_url }}
         run: ./hack/update-changelog.sh
 
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Create the pull request
         id: create-docs-pull-request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.ACTIONS_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           committer: bucketeer-bot <bucketeer-bot@users.noreply.github.com>
           author: bucketeer-bot <bucketeer-bot@users.noreply.github.com>
           commit-message: "docs: update ${{ github.event.inputs.doc_filename }} to ${{ github.event.inputs.release_tag }}"
@@ -77,7 +85,7 @@ jobs:
         id: automerge
         uses: pascalgn/automerge-action@7961b8b5eec56cc088c140b56d864285eabd3f67 # v0.16.4
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_PAT }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PULL_REQUEST: ${{ steps.create-docs-pull-request.outputs.pull-request-number }}
           MERGE_LABELS: automerge
           MERGE_METHOD: squash


### PR DESCRIPTION
Part of Part of https://github.com/bucketeer-io/bucketeer/issues/2703

Replaces ACTIONS_PAT / REPO_ACCESS_PAT with a short-lived installation token minted from a GitHub App for the changelog PR create/auto-merge, and uses the built-in GITHUB_TOKEN for public read-only API access.